### PR TITLE
help修正bootcmd追加

### DIFF
--- a/bios/Makefile
+++ b/bios/Makefile
@@ -9,6 +9,7 @@ endif
 OBJECTS = isr.o			\
 	  boot-helper.o		\
 	  boot.o			\
+		bootcmd.o    \
 	  helpers.o			\
 	  cmd_bios.o		\
 	  cmd_mem.o			\

--- a/bios/bootcmd.c
+++ b/bios/bootcmd.c
@@ -1,0 +1,33 @@
+#include <generated/csr.h>
+#include "bootcmd.h"
+
+const char *bootcmds = {
+#if defined( CSR_SB_SI5341_O_BASE ) && defined( CSR_SB_TCA9548_BASE )
+  "reset_si5341\n"  // reset external PLL IC
+  "set_si5341_n_divider 0 0 0x015 0x80000000 0x84000000\n"  // set GTY 1xx RefClk 161.1328125MHz
+  "set_si5341_n_divider 1 0 0x015 0x80000000 0x84000000\n"  // set GTY 2xx RefClk 161.1328125MHz
+  "reset_tca9548\n"  // reset I2C MUX
+  "reset_firefly\n"  // reset FireFly optical module
+#else
+  ""
+#endif
+};
+
+static int cmd_cur = 0;
+
+int getbootcmd(char *buf, int len)
+{
+  int i;
+  for (i = 0; i < len; i++) {
+    if (bootcmds[i+cmd_cur] == '\n') {
+      cmd_cur += i + 1;
+      buf[i] = '\0';
+      return i;
+    } else if (bootcmds[i+cmd_cur] == '\0') {
+      return 0;
+    }
+    buf[i] = bootcmds[i+cmd_cur];
+  }
+
+  return 0;
+}

--- a/bios/bootcmd.h
+++ b/bios/bootcmd.h
@@ -1,0 +1,1 @@
+int getbootcmd(char *buf, int len);

--- a/bios/command.h
+++ b/bios/command.h
@@ -9,17 +9,18 @@
 
 #define HIST_DEPTH	10	/* Used in string list, complete.c */
 
-#define SYSTEM_CMDS		0
-#define BOOT_CMDS		1
-#define MEM_CMDS		2
-#define SPIFLASH_CMDS	3
-#define I2C_CMDS		4
-#define LITEDRAM_CMDS	5
-#define LITEETH_CMDS	6
-#define LITESDCARD_CMDS	7
-#define LITESATA_CMDS	8
-#define NB_OF_GROUPS	9
-#define FIREFLY_CMDS    10
+#define SYSTEM_CMDS		   0
+#define BOOT_CMDS		     1
+#define MEM_CMDS		     2
+#define SPIFLASH_CMDS	   3
+#define I2C_CMDS		     4
+#define LITEDRAM_CMDS	   5
+#define LITEETH_CMDS	   6
+#define LITESDCARD_CMDS	 7
+#define LITESATA_CMDS	   8
+#define FIREFLY_CMDS     9
+#define NB_OF_GROUPS	  10
+
 
 typedef void (*cmd_handler)(int nb_params, char **params);
 

--- a/bios/main.c
+++ b/bios/main.c
@@ -22,6 +22,7 @@
 #include <irq.h>
 
 #include "boot.h"
+#include "bootcmd.h"
 #include "readline.h"
 #include "helpers.h"
 #include "command.h"
@@ -188,6 +189,19 @@ printf("\n");
 #if !defined(TERM_MINI) && !defined(TERM_NO_HIST)
 	hist_init();
 #endif
+
+	while(1) {
+		if (getbootcmd(buffer, CMD_LINE_BUFFER_SIZE) != 0) {
+			printf("\n%s%s\n", PROMPT, buffer);
+			nb_params = get_param(buffer, &command, params);
+			cmd = command_dispatcher(command, nb_params, params);
+			if (!cmd)
+				printf("Command not found");
+		} else {
+			break;
+		}
+	}
+
 	printf("\n%s", PROMPT);
 	while(1) {
 		readline(buffer, CMD_LINE_BUFFER_SIZE);

--- a/bios/trefoil_dev.c
+++ b/bios/trefoil_dev.c
@@ -11,7 +11,7 @@ void trefoil_clock_gen_reset(void)
 	DELAY_MS(500);
 	return;
 }
-define_init_func(trefoil_clock_gen_reset);
+// define_init_func(trefoil_clock_gen_reset);
 #endif
 
 #ifdef CSR_SB_TCA9548_BASE
@@ -23,5 +23,5 @@ void trefoil_iicio_reset(void)
     DELAY_MS(500);
 	return;
 }
-define_init_func(trefoil_iicio_reset);
+// define_init_func(trefoil_iicio_reset);
 #endif


### PR DESCRIPTION
helpコマンドを正しく表示できるように修正。
ブート時にコマンドを自動で実行できる機能を実装。
Trefoil向けにFireFlyモジュールを初期化するブートコマンドを実装。
trefoil_dev.cはブートコマンドに内包されたので、コメントアウトで無効化。